### PR TITLE
allow --force-arch to proceed with a warning, skip ELF checks also when using it

### DIFF
--- a/ares-package/src/input/data.rs
+++ b/ares-package/src/input/data.rs
@@ -88,8 +88,8 @@ impl DataInfo {
 }
 
 impl Validation for DataInfo {
-    fn validate(&self) -> Result<ValidationInfo> {
-        let app_validation = self.app.validate()?;
+    fn validate(&self, force_arch: bool) -> Result<ValidationInfo> {
+        let app_validation = self.app.validate(force_arch)?;
         let mut archs = HashSet::<PackageArch>::new();
         let mut size_sum = self.package_data.len() as u64;
         if let Some(arch) = &app_validation.arch {
@@ -98,14 +98,14 @@ impl Validation for DataInfo {
         size_sum += app_validation.size;
 
         for info in &self.services {
-            let service_validation = info.validate()?;
+            let service_validation = info.validate(force_arch)?;
             if let Some(arch) = &service_validation.arch {
                 archs.insert(arch.clone());
             }
             size_sum += service_validation.size;
         }
 
-        if archs.len() > 1 {
+        if archs.len() > 1 && !force_arch {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 "Mixed architecture is not allowed",

--- a/ares-package/src/input/validation.rs
+++ b/ares-package/src/input/validation.rs
@@ -26,27 +26,27 @@ pub struct ValidationInfo {
 }
 
 pub trait Validation {
-    fn validate(&self) -> Result<ValidationInfo>;
+    fn validate(&self, force_arch: bool) -> Result<ValidationInfo>;
 }
 
 impl Validation for ComponentInfo<AppInfo> {
-    fn validate(&self) -> Result<ValidationInfo> {
+    fn validate(&self, force_arch: bool) -> Result<ValidationInfo> {
         let size = dir_size(&self.path, self.excludes.as_ref())?;
         let mut arch: Option<PackageArch> = None;
         if self.info.r#type == "native" {
-            arch = infer_arch(self.path.join(&self.info.main))?;
+            arch = infer_arch(self.path.join(&self.info.main), force_arch)?;
         }
         Ok(ValidationInfo { arch, size })
     }
 }
 
 impl Validation for ComponentInfo<ServiceInfo> {
-    fn validate(&self) -> Result<ValidationInfo> {
+    fn validate(&self, force_arch: bool) -> Result<ValidationInfo> {
         let size = dir_size(&self.path, self.excludes.as_ref())?;
         let mut arch: Option<PackageArch> = None;
         if let (Some(engine), Some(executable)) = (&self.info.engine, &self.info.executable)
             && engine == "native" {
-                arch = infer_arch(self.path.join(executable))?;
+                arch = infer_arch(self.path.join(executable), force_arch)?;
             }
         Ok(ValidationInfo { arch, size })
     }
@@ -76,15 +76,21 @@ impl FromStr for PackageArch {
     }
 }
 
-fn infer_arch<P: AsRef<Path>>(path: P) -> Result<Option<PackageArch>> {
+fn infer_arch<P: AsRef<Path>>(path: P, allow_unknown: bool) -> Result<Option<PackageArch>> {
     let elf = ElfStream::<AnyEndian, _>::open_stream(File::open(path.as_ref())?)
         .map_err(|e| Error::new(ErrorKind::InvalidData, format!("Bad binary: {e:?}")))?;
     match elf.ehdr.e_machine {
         elf::abi::EM_ARM => Ok(Some(PackageArch::ARM)),
         elf::abi::EM_386 => Ok(Some(PackageArch::X86(String::from("x86")))),
-        e => Err(Error::new(
-            ErrorKind::InvalidData,
-            format!("Unsupported binary machine type {}", e_machine_to_string(e)),
-        )),
+        other => {
+            if allow_unknown {
+                Ok(None)
+            } else {
+                Err(Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Unsupported binary machine type {}", e_machine_to_string(other)),
+                ))
+            }
+        }
     }
 }

--- a/ares-package/src/main.rs
+++ b/ares-package/src/main.rs
@@ -70,9 +70,10 @@ fn main() {
 
     let data = DataInfo::from_input(&app_dir, &cli.service_dir, &cli.app_exclude).unwrap();
     let package_info = &data.package;
-    let validation = data.validate().unwrap();
-    let arch = cli
-        .force_arch
+    let validation = data.validate(cli.force_arch.is_some()).unwrap();
+    let forced = cli.force_arch.clone();
+    let arch = forced
+        .clone()
         .or_else(|| validation.arch.clone())
         .unwrap_or(PackageArch::ALL);
     if let Some(validation_arch) = &validation.arch
@@ -80,6 +81,9 @@ fn main() {
     {
         eprintln!("Incompatible architecture: {arch} != {validation_arch}");
         return;
+    }
+    if forced.is_some() {
+        eprintln!("Warning: architecture {} was explicitly forced via -A", arch);
     }
 
     let path = outdir.join(format!(


### PR DESCRIPTION
This is needed to package up the bridge (for use by .github workflows)

Also to be used by aarch64 IPKs

