### PR TITLE
Add device list command to ares-device CLI

### DIFF
--- a/ares-device/src/main.rs
+++ b/ares-device/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 
 mod picker;
 
-use ares_device_lib::DeviceManager;
+use ares_device_lib::{Device, DeviceManager};
 use picker::{DeviceSelection, PickDevice};
 
 #[derive(Parser, Debug)]
@@ -20,11 +20,19 @@ struct Cli {
         help = "Specify DEVICE to use, show picker if no value specified"
     )]
     device: Option<DeviceSelection>,
+    #[arg(short = 'D', long = "device-list", help = "List the available devices")]
+    device_list: bool,
 }
 
 fn main() {
     let cli = Cli::parse();
     let manager = DeviceManager::default();
+
+    if cli.device_list {
+        list_devices(&manager);
+        return;
+    }
+
     let device = if let Some(d) = manager.pick(cli.device.as_ref()).unwrap() {
         d
     } else {
@@ -32,4 +40,58 @@ fn main() {
         exit(1);
     };
     println!("{}", device.name);
+}
+
+fn list_devices(manager: &DeviceManager) {
+    let devices = manager.list().unwrap_or_else(|e| {
+        eprintln!("Failed to list devices: {e:?}");
+        exit(1);
+    });
+
+    let headers = ["name", "deviceinfo", "connection", "profile", "passphrase"];
+    let rows: Vec<[String; 5]> = devices.iter().map(device_row).collect();
+    print_table(&headers, &rows);
+}
+
+fn device_row(device: &Device) -> [String; 5] {
+    let name = if device.default == Some(true) {
+        format!("{} (default)", device.name)
+    } else {
+        device.name.clone()
+    };
+    [
+        name,
+        format!("{}@{}:{}", device.username, device.host, device.port),
+        String::from("ssh"),
+        device.profile.clone(),
+        device.passphrase.clone().unwrap_or_default(),
+    ]
+}
+
+/// Prints a left-aligned, space-padded table with a dashed header underline,
+/// mirroring the reference CLI's device list output.
+fn print_table<const N: usize>(headers: &[&str; N], rows: &[[String; N]]) {
+    let mut widths = headers.map(str::len);
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cell.len());
+        }
+    }
+
+    let print_row = |cells: &[String; N]| {
+        let line: Vec<String> = cells
+            .iter()
+            .enumerate()
+            .map(|(i, cell)| format!("{cell:<width$}", width = widths[i]))
+            .collect();
+        println!("{}", line.join("  ").trim_end());
+    };
+
+    let header_row: [String; N] = std::array::from_fn(|i| headers[i].to_string());
+    let separator_row: [String; N] = std::array::from_fn(|i| "-".repeat(widths[i]));
+    print_row(&header_row);
+    print_row(&separator_row);
+    for row in rows {
+        print_row(row);
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds a new `--device-list` flag to the ares-device CLI that displays all available devices in a formatted table.

## Key Changes
- Added `-D, --device-list` command-line argument to show available devices
- Implemented `list_devices()` function to retrieve and display devices from the DeviceManager
- Implemented `device_row()` helper to format device information into table rows
- Implemented `print_table()` generic function to render left-aligned, space-padded tables with dashed header underlines
- Updated imports to include the `Device` type from ares_device_lib
- Added early return in main() when `--device-list` flag is provided

## Notable Implementation Details
- The table formatting mirrors the reference CLI's device list output with consistent spacing and alignment
- Device names are annotated with "(default)" when the device is marked as the default
- Device connection info is displayed as `username@host:port` in the deviceinfo column
- Connection type is hardcoded as "ssh" for all devices
- Passphrases are displayed as empty strings if not set
- The `print_table()` function is generic over the number of columns, automatically calculating column widths based on content

https://claude.ai/code/session_017vAGzSSYNcgdQzJRLWfX47